### PR TITLE
feat: add support for nvim-treesitter main branch

### DIFF
--- a/lua/tree-sitter-rstml.lua
+++ b/lua/tree-sitter-rstml.lua
@@ -1,21 +1,20 @@
-local parsers = require("nvim-treesitter.parsers").get_parser_configs()
-
 local M = {}
 
-function M.init()
-    parsers.rust_with_rstml = {
-        install_info = {
-            url = "https://github.com/rayliwell/tree-sitter-rstml",
-            branch = "main",
-            files = { "src/parser.c", "src/scanner.c" },
-            location = "rust_with_rstml",
-        },
-        filetype = "rust"
-    }
-end
-
 function M.setup()
-    vim.treesitter.language.register("rust", { "rust_with_rstml" })
+	local parsers = require("nvim-treesitter.parsers")
+	local configs = parsers.configs and parsers.configs or parsers.get_parser_configs()
+
+	configs.rust_with_rstml = {
+		install_info = {
+			url = "https://github.com/rayliwell/tree-sitter-rstml",
+			branch = "main",
+			files = { "src/parser.c", "src/scanner.c" },
+			location = "rust_with_rstml",
+		},
+		filetype = "rust",
+	}
+
+	vim.treesitter.language.register("rust_with_rstml", { "rust" })
 end
 
 return M

--- a/lua/tree-sitter-rstml.lua
+++ b/lua/tree-sitter-rstml.lua
@@ -2,6 +2,7 @@ local M = {}
 
 function M.setup()
 	local parsers = require("nvim-treesitter.parsers")
+	-- Support nvim-treesitter versions before and after 1.10.
 	local configs = parsers.configs and parsers.configs or parsers.get_parser_configs()
 
 	configs.rust_with_rstml = {

--- a/lua/tree-sitter-rstml.lua
+++ b/lua/tree-sitter-rstml.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-function M.setup()
+function M.init()
 	local parsers = require("nvim-treesitter.parsers")
 	-- Support nvim-treesitter versions before and after 1.10.
 	local configs = parsers.configs and parsers.configs or parsers.get_parser_configs()
@@ -14,7 +14,9 @@ function M.setup()
 		},
 		filetype = "rust",
 	}
+end
 
+function M.setup()
 	vim.treesitter.language.register("rust_with_rstml", { "rust" })
 end
 

--- a/plugin/tree-sitter.rstml.vim
+++ b/plugin/tree-sitter.rstml.vim
@@ -1,1 +1,0 @@
-lua require("tree-sitter-rstml").init()

--- a/plugin/tree-sitter.rstml.vim
+++ b/plugin/tree-sitter.rstml.vim
@@ -1,0 +1,1 @@
+lua require("tree-sitter-rstml").init()


### PR DESCRIPTION
Hi! Thank you so much for creating this! I have been wanting this for a long time now.

I have been migrating to the main-branch of nvim-treesitter, which will become the default branch once 0.10 is released. With that branch, the code is not exactly the same, and is now stored in a table `configs`. I changed to code to try `configs` which will become the default, and then fallback to the way it works in the `master` branch. This should not affect anything, and just add support for the `main` branch.

I also removed the `plugin` folder which calls `init()`. This is to move the require of `nvim-treesitter` into the setup-function in case someone is lazy-loading nvim-treesitter.

PS: I also noticed that the arguments to `vim.treesitter.language.register` was in the wrong order, and that the `lang` should be the first argument, while the table of filetypes is the second