### PR TITLE
fix: nvim-treesitter main branch support after breaking change

### DIFF
--- a/lua/tree-sitter-rstml.lua
+++ b/lua/tree-sitter-rstml.lua
@@ -1,19 +1,30 @@
 local M = {}
 
 function M.init()
-	local parsers = require("nvim-treesitter.parsers")
-	-- Support nvim-treesitter versions before and after 1.10.
-	local configs = parsers.configs and parsers.configs or parsers.get_parser_configs()
-
-	configs.rust_with_rstml = {
-		install_info = {
-			url = "https://github.com/rayliwell/tree-sitter-rstml",
-			branch = "main",
-			files = { "src/parser.c", "src/scanner.c" },
-			location = "rust_with_rstml",
-		},
-		filetype = "rust",
+	local install_info = {
+		url = "https://github.com/rayliwell/tree-sitter-rstml",
+		branch = "main",
+		files = { "src/parser.c", "src/scanner.c" },
+		location = "rust_with_rstml",
 	}
+
+	local ok, parsers = pcall(require("nvim-treesitter.parsers").get_parser_configs)
+	if ok then
+		parsers.rust_with_rstml = {
+			install_info = install_info,
+			filetype = "rust",
+		}
+	else
+		-- Support nvim-treesitter versions before and after 1.10.
+		vim.api.nvim_create_autocmd("User", {
+			pattern = "TSUpdate",
+			callback = function()
+				require("nvim-treesitter.parsers").rust_with_rstml = {
+					install_info = install_info,
+				}
+			end,
+		})
+	end
 end
 
 function M.setup()


### PR DESCRIPTION
`nvim-treesitter` main had some breaking changes today, and since I was the one that implemented support for the main branch, I think it is my job to stay up to date and fix this since neovim 0.10 isn't release yet, and the main branch isn't stabilized yet😅 I didn't test this on `nvim-treesitter` master branch, but from what I can se, it should work exactly like before.

I also just removed the `filetype` from the config table for `nvim-treesitter` main branch, since they don't use that anymore

Context:

https://github.com/nvim-treesitter/nvim-treesitter/tree/main?tab=readme-ov-file#adding-parsers