### PR TITLE
flake: prevent duplicate copies to nix store

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   };
 
   outputs =
-    { nixpkgs, ... }:
+    { nixpkgs, self, ... }:
     let
       forAllSystems =
         function:
@@ -26,7 +26,7 @@
               grammarName:
               pkgs.tree-sitter.buildGrammar {
                 version = "2.0.0";
-                src = ./.;
+                src = self.outPath;
                 generate = false;
                 location = grammarName;
                 language = grammarName;


### PR DESCRIPTION
Prevent unnecessarily copying source to the nix store again.

Resolves warning when evaluating in Determinate Nix:
```
warning: Copying '/<path>/tree-sitter-rstml/' to the store again
You can make Nix evaluate faster and copy fewer files by replacing `./.` with the `self` flake input, or `builtins.path { path = ./.; name = "source"; }`
```